### PR TITLE
Move lru_cache definitions to __init__

### DIFF
--- a/dissect/squashfs/squashfs.py
+++ b/dissect/squashfs/squashfs.py
@@ -29,11 +29,6 @@ class SquashFS:
     def __init__(self, fh: BinaryIO):
         self.fh = fh
 
-        self._read_block = lru_cache(1024)(self._read_block)
-        self._lookup_id = lru_cache(1024)(self._lookup_id)
-        self._lookup_inode = lru_cache(1024)(self._lookup_inode)
-        self._lookup_fragment = lru_cache(1024)(self._lookup_fragment)
-
         sb = c_squashfs.squashfs_super_block(fh)
         if sb.s_magic != c_squashfs.SQUASHFS_MAGIC:
             raise ValueError("Invalid squashfs superblock")
@@ -50,6 +45,11 @@ class SquashFS:
         self.major = self.sb.s_major
         self.minor = self.sb.s_minor
         self.size = self.sb.bytes_used
+
+        self._read_block = lru_cache(1024)(self._read_block)
+        self._lookup_id = lru_cache(1024)(self._lookup_id)
+        self._lookup_inode = lru_cache(1024)(self._lookup_inode)
+        self._lookup_fragment = lru_cache(1024)(self._lookup_fragment)
 
         self._compression_options = None
         if (self.sb.flags >> c_squashfs.SQUASHFS_COMP_OPT) & 1:


### PR DESCRIPTION
Using the lru_cache decorators on class methods, the ones that have a reference to `self`,
will also cache self. So we move it to the __init__ of the class
    
(DIS-2913)