### PR TITLE
Remove lzo and lz4 dependency groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,10 @@ Information on the supported Python versions can be found in the Getting Started
 pip install dissect.squashfs
 ```
 
-This project decompresses lzo and lz4 compressed file systems and can use the faster, native (C-based) lz4 and lzo
-implementations when installed, instead of the slower pure Python implementation provided by `dissect.util`. To use
-these faster implementations, install the package with the lzo and lz4 extras:
-
-```bash
-pip install "dissect.squashfs[lz4,lzo]"
-```
-
-Unfortunately there is no binary `python-lzo` wheel for PyPy installations on Windows, so it won't be installed there
-
-This module including the lz4 and lzo extras is also automatically installed if you install the `dissect` package.
+This project decompresses LZO and LZ4 compressed file systems and can use a faster, native (Rust-based) LZO or LZ4 implementation,
+instead of a slower pure Python implementation. Both implementations are provided by `dissect.util`.
+Pre-build wheels are available for most common platforms and the native implementation will automatically be used if available.
+In the rare case that a pre-build wheel is not available, please refer to `dissect.util` for build instructions.
 
 ## Build and test instructions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,6 @@ repository = "https://github.com/fox-it/dissect.squashfs"
 full = [
     "zstandard",
 ]
-lzo = [
-    # There are no Windows PyPy wheels available for python-lzo
-    # So we use a pure python fallback for it.
-    "python-lzo; platform_system != 'Windows' or platform_python_implementation != 'PyPy'",
-]
-lz4 = [
-    "lz4",
-]
 dev = [
     "dissect.squashfs[full]",
     "dissect.cstruct>=4.0.dev,<5.0.dev",


### PR DESCRIPTION
It's now available in dissect.util